### PR TITLE
Automatically rebuild when running on local environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,5 +11,13 @@ services:
       - "80:80"
   lobby:
     network_mode: "host"
+    build:
+      context: .
+      dockerfile: "./docker/zdxsv/Dockerfile"
+    command: lobby
   battle:
     network_mode: "host"
+    build:
+      context: .
+      dockerfile: "./docker/zdxsv/Dockerfile"
+    command: battle

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,18 +6,13 @@ services:
     environment:
       DOMAINS: 'zdxsv.example.com -> http://web:80'
       STAGE: 'local'
+
   web:
     ports:
       - "80:80"
+
   lobby:
     network_mode: "host"
-    build:
-      context: .
-      dockerfile: "./docker/zdxsv/Dockerfile"
-    command: lobby
+
   battle:
     network_mode: "host"
-    build:
-      context: .
-      dockerfile: "./docker/zdxsv/Dockerfile"
-    command: battle

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,3 +3,43 @@ services:
   web:
     ports:
       - "1080:80"
+
+  dns:
+    build:
+      target: builder
+    entrypoint: /build_and_run.sh
+    volumes:
+      - ./src:/work/src:ro
+      - ./pkg:/work/pkg:ro
+
+  lobby:
+    build:
+      target: builder
+    entrypoint: /build_and_run.sh
+    volumes:
+      - ./src:/work/src:ro
+      - ./pkg:/work/pkg:ro
+
+  login:
+    build:
+      target: builder
+    entrypoint: /build_and_run.sh
+    volumes:
+      - ./src:/work/src:ro
+      - ./pkg:/work/pkg:ro
+
+  battle:
+    build:
+      target: builder
+    entrypoint: /build_and_run.sh
+    volumes:
+      - ./src:/work/src:ro
+      - ./pkg:/work/pkg:ro
+
+  status:
+    build:
+      target: builder
+    entrypoint: /build_and_run.sh
+    volumes:
+      - ./src:/work/src:ro
+      - ./pkg:/work/pkg:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - "443:443"
   https-portal:
     image: hello-world
+
   web:
     restart: always
     build: "./docker/web"
@@ -29,6 +30,7 @@ services:
   legacyweb:
     restart: always
     build: "./docker/legacyweb"
+
   dns:
     build:
       context: .
@@ -37,6 +39,7 @@ services:
     ports:
       - "53:53/udp"
     environment: *zdxsv-environment
+
   login:
     build:
       context: .
@@ -45,6 +48,7 @@ services:
     volumes:
       - ./zdxsv.db:/zdxsv.db
     environment: *zdxsv-environment
+
   lobby:
     build:
       context: .
@@ -57,15 +61,17 @@ services:
     volumes:
       - ./zdxsv.db:/zdxsv.db
     environment: *zdxsv-environment
+
   battle:
     build:
       context: .
       dockerfile: "./docker/zdxsv/Dockerfile"
-    command: battle 
+    command: battle
     ports:
       - "8210:8210"
       - "8210:8210/udp"
     environment: *zdxsv-environment
+
   status:
     build:
       context: .

--- a/docker/zdxsv/Dockerfile
+++ b/docker/zdxsv/Dockerfile
@@ -5,14 +5,17 @@ COPY go.mod go.sum ./
 RUN go mod download
 ADD src src
 ADD pkg pkg
-RUN go build -o ./bin/zdxsv \
+RUN go build -o /zdxsv \
   -tags netgo \
   -installsuffix netgo \
   --ldflags '-extldflags "-static"' \
   ./src/zdxsv
 
+WORKDIR /
+COPY docker/zdxsv/build_and_run.sh .
+
 
 FROM alpine
 WORKDIR /
-COPY --from=builder /work/bin /
+COPY --from=builder /zdxsv /zdxsv
 ENTRYPOINT ["/zdxsv"]

--- a/docker/zdxsv/build_and_run.sh
+++ b/docker/zdxsv/build_and_run.sh
@@ -6,4 +6,4 @@ go build -o /zdxsv \
   --ldflags '-extldflags "-static"' \
   ./src/zdxsv
 cd /
-/zdxsv -v=3 "$@"
+exec /zdxsv -v=3 "$@"

--- a/docker/zdxsv/build_and_run.sh
+++ b/docker/zdxsv/build_and_run.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
-cd work
-go build -o /zdxsv \
+cd work && go build -o /zdxsv \
   -tags netgo \
   -installsuffix netgo \
   --ldflags '-extldflags "-static"' \
-  ./src/zdxsv
-cd /
-exec /zdxsv -v=3 "$@"
+  ./src/zdxsv && \
+  cd / && exec /zdxsv -v=3 "$@"

--- a/docker/zdxsv/build_and_run.sh
+++ b/docker/zdxsv/build_and_run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+cd work
+go build -o /zdxsv \
+  -tags netgo \
+  -installsuffix netgo \
+  --ldflags '-extldflags "-static"' \
+  ./src/zdxsv
+cd /
+/zdxsv -v=3 "$@"

--- a/src/zdxsv/lobby.go
+++ b/src/zdxsv/lobby.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"zdxsv/pkg/config"
@@ -15,8 +16,8 @@ func mainLobby() {
 	go sv.ServeUDPStunServer(stripHost(config.Conf.Lobby.RPCAddr))
 
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-
-	<-c
+	signal.Notify(c)
+	s := <-c
+	fmt.Println("Got signal:", s)
 	app.Quit()
 }

--- a/src/zdxsv/main.go
+++ b/src/zdxsv/main.go
@@ -81,6 +81,8 @@ func main() {
 	flag.Parse()
 	rand.Seed(time.Now().UnixNano())
 
+	glog.Infoln("zdxsv - Gundam vs Zeta Gundam private game server.")
+
 	args := flag.Args()
 	glog.Infoln(args, len(args))
 


### PR DESCRIPTION
To increase development efficiency, use `builder` step of docker image and automatically rebuild go sources before run binary.

After editing source code, just run `docker-compose restart lobby` to apply the change.