### PR TITLE
register user when login key is valid length but not found

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -67,6 +67,7 @@ type User struct {
 type DB interface {
 	Init() error
 	RegisterAccount(ip string) (*Account, error)
+	RegisterAccountWithLoginKey(ip string, loginKey string) (*Account, error)
 	GetAccountByLoginKey(key string) (*Account, error)
 	LoginAccount(*Account) error
 	RegisterUser(loginKey string) (*User, error)

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -2,9 +2,10 @@ package db
 
 import (
 	"database/sql"
+	"time"
+
 	_ "github.com/golang/glog"
 	_ "github.com/mattn/go-sqlite3"
-	"time"
 )
 
 type SQLiteDB struct {
@@ -63,6 +64,23 @@ VALUES
 	}
 	a := &Account{
 		LoginKey:  key,
+		CreatedIP: ip,
+	}
+	return a, nil
+}
+
+func (db SQLiteDB) RegisterAccountWithLoginKey(ip string, loginKey string) (*Account, error) {
+	now := time.Now()
+	_, err := db.Exec(`
+INSERT INTO account
+	(login_key, created_ip, created, last_login, system)
+VALUES
+	(?, ?, ?, ?, ?)`, loginKey, ip, now, now, 0)
+	if err != nil {
+		return nil, err
+	}
+	a := &Account{
+		LoginKey:  loginKey,
 		CreatedIP: ip,
 	}
 	return a, nil


### PR DESCRIPTION
Since the HK server is established, in order to be able to go back and forth between the HK server and the JP server without purchasing an additional memory card, new registration is automatically performed for valid login keys.